### PR TITLE
Use a narrow type for `htmlElementAttributes`

### DIFF
--- a/build.js
+++ b/build.js
@@ -84,10 +84,8 @@ await fs.writeFile(
   [
     '/**',
     ' * Map of HTML elements to allowed attributes.',
-    ' *',
-    ' * @type {Record<string, Array<string>>}',
     ' */',
-    'export const htmlElementAttributes = ' + JSON.stringify(result, null, 2),
+    'export const htmlElementAttributes = /** @type {const} */ (' + JSON.stringify(result, null, 2) + ')',
     ''
   ].join('\n')
 )

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 /**
  * Map of HTML elements to allowed attributes.
- *
- * @type {Record<string, Array<string>>}
  */
-export const htmlElementAttributes = {
+export const htmlElementAttributes = /** @type {const} */ ({
   '*': [
     'accesskey',
     'autocapitalize',
@@ -404,4 +402,4 @@ export const htmlElementAttributes = {
     'src',
     'width'
   ]
-}
+})

--- a/readme.md
+++ b/readme.md
@@ -94,8 +94,7 @@ There is no default export.
 
 ### `htmlElementAttributes`
 
-Map of lowercase HTML elements to allowed attributes
-(`Record<string, Array<string>>`).
+Map of lowercase HTML elements to allowed attributes.
 
 ## Types
 


### PR DESCRIPTION
A [const assertion][1] is now used for `htmlElementAttributes` to make its TypeScript type include specific element & attribute names.

[Here's](https://www.typescriptlang.org/play/?filetype=js#code/PQKhCgAIUhZBDADpA9gM0gCQCqwDKQCmANoQLaEB2ALgM6TUqTzHEoDuhAJs9dQE4BLAEYBXaoVoA6KCGDhCAD0Qp+1SAGMUlWuoAW1MsQCipCjQCCfIWIn0AvJFAwAAtQCeiQpADeWndQAvtDAkAAUPlCQAEQg0QBckADaUZAx8BoakrQA1oTu0QA0qeniKBpIgtQsggBehEUl0fBlWvz8hBrUjWlpzWVo5aK0Pb3RGsTwtCPFvTH+EjTcVfDCpKN9XIL8GzFc-PAA5oer67NjVBL8ee56gjS70UoqaojwajNNd1xcVI+CXH+lEIaiBiHEZBQv3+nzm0Sq5AB-wkZEQ-BQiGR5A6aCxZFoWi8eI8RPOfUmlEOj0o2iyjzeoLJMRUKgAbiDHrQ2N0mdFaF5WBo9J0cpyPGcmtVhPdfopHtQqhK4QJ4DpJhJHuwhArKbRRMdJArtCMogBdc7NBLJJpC960Qg8m0oVRcWFjLgcShseCA3l6HGPf2ENAUqm8yjwCj0+5hpo4kEdfgqYiCDQFXkdYiPDqszl6JANXnVfiHB3yzwNM0WpCIUjdRIpOE1Q6UR4sR1N-hCwTsx5aaG8-uEYRTQtfQiCQ4GQP8jJjuERqO8lDCABWnQ7Y1Zs7pvPYAOoemiVaizQ68CtjbG7b7zv4rseHvYXpQPsDAb9OND1JQQdxvMQGNs2DBMQWTVN0zjEg8wLeV3lLTc+hJSs0nNU8Wi2FBLyaFpGFreBILhBZ0WIN0+g0dFplUSd7keNgMUeMhxG4elM1fX0mloLtj1Qi0R3tbC4T-OCSzLE8+n44NtHra0iJQNgdl5NA505OoUMgNCJLYDQcgAR1EFANQbG0ER4jS+KhApjKbFNKFFXkRx0w50VESgOLhYRDi0BS6PuezJSURCYlZWzRXEmJhB2ayxgmQh3jMzSIvERhW2i8iUDIMhVXcmKMqytzBkUpotloU4WKU1QyEeQqsq6QRtGqyqqC6CtGv4TKHT0KE2rIGlWRqLh4A1Cr2uLBDqUjecxhZFB2TUeCywAjFZpBMaHQyI1WyLVreX64hRHUxLxlVfqRjSmJhUnac9wPI9wuOxBNsE68UxbBKLW856+mbLabXzIqiP+9B-04t5frhPbJ3BsZ9y4Q93tPbznJQURMXO5pXuh8j-r7IG0BBuFZyx4Kfs1W6Ec2IaL3RvaDopvZoPRjRTN5QaJAVKN7t+apBFIr6YkXKa+gxP4ucEFgUCpJm2HtLhhEIsYRdbMWotk3LUQ2+noi2XN0dJrmsyZjK3i6LXyGEFj0cuqcgr5bjttJJpYfh+60EEEhXTLdGSrKnK+hqibOd409BgeI2fKUlTeVoNStYDvXMkIR620Tx6AFpbX4e1bY2+rif6RgtFROshZiZrkMYzruvDSaf0htnS+iNbuldg4o3RtA2+HF0OV5NhKV+AlGPg+5reupospLe5naPGulyaGkOhj+pOQo+TbNjQnuNbybs-58Z5LImJ0XYE1g76PQAEZ9-18+LoAJhvzGtb0ABmJ+oZfgAWD+3vuvQACsv9lZ32iHoAAbMAl+cVATozROgXmh0LT+igeGFAtB8wDk4rHG6cM7qgIMEYfe+VBBoENI8OaMcGr3VIV3VBOFWAcDbIw9gaBRCsAJB0P4vIWBsHYG8dw5gBCEH0uQnhLDhgggoFsC8Sku7CB7gDMYY9bbei2JSOi2hDiDw0MPKelAVF6MONPcmc9G7xnaGBeSEFOTZQUXKaOa9WBAWjvbTiXYPS6NwS7UBggyBSzVt9Z+4jbYKPvL3G0lFaDUWMfnX4-YXFNDIdQIUaJ6ragVhfCcNsZwm0boIWgWVMR93YokuE-dtGSC8QvWuGYQKWKTNYtMql6hHzttUreGg968kkUUihO5G4zy1vccEMkrzfVTjnYJDDED5mYTnVoxsS64xFOVJ0CkBmPm2ILLZpU1hrLhAHEatUnrHPLjtJJlUKCHmrpc9qfUBpDUbjVZugZsnjzhAUvpfcCm2yyg4ie8BFCkEpPDXkZBaLgvuCCw4YKJ7sIVLWRuOyAJDSuPnfCWQurEF+EovoM05qvKWmyVaC1qh1QanUn02hiCZOPiI0Q2wDljGXo3LiHSWUSGKZKC5cJelIAoSwOm3j8HmVPPcM6gT5gs2Kk8jmSDxUxzckofe8DUQt1AZMC2hspXREKj1LWpBSxuSgfdFM+8K67SFQq8kfkb5tLWOUHIZSYr-W6es1QfYokxMhcVApvtqoOlSUIaiHh3zBnDSGVUm8xh+KOJINSbS42lnZe6z5SxnJVDpdEaR4tgJkIaeBZpdSsx1NzNHRNIlxoOxtTEPp6Mdn3XMKIfeRcTYarFX0a51NdWZzTblJYDw-R8EQGnBlPZK4yMDmyoU5Ba05odByK2V1NHsGHgCuEEL84Yg5qIKqVr9rzpXOuU2etpmdm7L2Byii+yTGmEiQcUJhyjlvNzXl7oqaPk6JMDoBq-TvNtnoTZZixR2OzZanlXgmK6Cyik2eTR+XcohsBp25N7ryVbcbTWZaQSy1A4ySDR7HrI1RvvH2+y-YxC1dBdDj085kf9RRuiqxoLRxIBuZlfRaZHvEKM-e+rjnTq1mjXVt9O3MneJGfeKLCOCsPXJg6Fd7pogaOjIZyn0TOWyMQoFCn526VbaZe6nDBDJz1rQdwlAOVaSdS67GdpFqRPQdEoQsSv0FsDXBtJobs33AkJmsNfdo2iHjT+SEXB2HmPqYmIt2b2XliJMZ9jp7ROLOLou3ZAbBPgoRaZpUYwZNwg6PpJllG+Sx2M9yaTtdjMoy7Kp3VhjwXLFkdg1pnI3GdP7Uhd9fR1OgN0O4dY6NHU6Ts3WlrCX51SmG6J89YxPLeU9de8JeL5gkGIG8H443xgbZ3DtzutS4yRbaXqTK7xs39fE03BRXArJzc-oOHGT33jAzk5-e61BYGieEJFZhj2cKKAKY8Rb8llt-Xii99E+NbykTBm8n0uG3lXVtjSLUAqMwcCJqvEW723oiq1iifCRldUYOpVqZ0KT+5lRgk+dEhkNDDEYBQMwlwOjGN0PwOLmCOD06++xk4dhBiM9OzzinhlwtsrF3z+0Qgai1Bp59wK7w4o3zS0i4a6y2lbH4IV90jHSBlaOYC4FVBYXwc3dCs3cKFxHbhJiwg2LcXAWpV6bNxXGUdDKyfNp6PMSfcGIZehgNIcQ+hwTLcYmjrwz1r9tbGMAdNiBw6ryYP4+Z1xq9mHj64eqgR7itpTWF684x3GLH8PHG44PYnmGaHQGHhgcH11oeQ-h7xyA678qyNyr8dN1W4z0jzYkqniOYfM9t+r3-evBwdJkeDC0YgttnUmqC9qjr1mYjsu-PddhmGNamxrVrVkAJCBYT1mUfC2biKHy9c5n1+ci-lOdEhsYTEJBlcv0q2yjcVC6AifbtiN8VxDfaIK7U0cAQIAASnACAA) what the type looks like now:

<img width="900" height="233" alt="Screenshot 2025-09-15 at 5 52 48 PM" src="https://github.com/user-attachments/assets/f71477e7-0f94-4c73-9ddf-e0fe5f620451" />

[1]: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions